### PR TITLE
Highlight AS and BY when capitalized

### DIFF
--- a/splunk.JSON-tmLanguage
+++ b/splunk.JSON-tmLanguage
@@ -33,7 +33,7 @@
         },
 
         {
-            "match": "\\b(AND|OR|as|by)\\b",
+            "match": "\\b(AND|OR|as|AS|by|BY)\\b",
             "comment": "Splunk Operators",
             "name": "keyword.operator.splunk"
         },

--- a/splunk.tmLanguage
+++ b/splunk.tmLanguage
@@ -53,7 +53,7 @@
 			<key>comment</key>
 			<string>Splunk Operators</string>
 			<key>match</key>
-			<string>\b(AND|OR|as|by)\b</string>
+			<string>\b(AND|OR|as|AS|by|BY)\b</string>
 			<key>name</key>
 			<string>keyword.operator.splunk</string>
 		</dict>


### PR DESCRIPTION
The docs (at least for `stats`) have the AS and BY words listed in all caps. This should allow them to be picked up as well.